### PR TITLE
fix: handle invalid requests and update tests

### DIFF
--- a/service/src/index.js
+++ b/service/src/index.js
@@ -50,7 +50,7 @@ export default {
       });
     } catch (err) {
       return new Response(JSON.stringify({ error: "Invalid request" }), {
-        status: 500,
+        status: 400,
         headers: { "Content-Type": "application/json" },
       });
     }

--- a/service/test/index.spec.js
+++ b/service/test/index.spec.js
@@ -1,20 +1,64 @@
-import { env, createExecutionContext, waitOnExecutionContext, SELF } from 'cloudflare:test';
-import { describe, it, expect } from 'vitest';
+import { env, createExecutionContext, waitOnExecutionContext } from 'cloudflare:test';
+import { describe, it, expect, vi } from 'vitest';
 import worker from '../src';
 
-describe('Hello World worker', () => {
-	it('responds with Hello World! (unit style)', async () => {
-		const request = new Request('http://example.com');
-		// Create an empty context to pass to `worker.fetch()`.
-		const ctx = createExecutionContext();
-		const response = await worker.fetch(request, env, ctx);
-		// Wait for all `Promise`s passed to `ctx.waitUntil()` to settle before running test assertions
-		await waitOnExecutionContext(ctx);
-		expect(await response.text()).toMatchInlineSnapshot(`"Hello World!"`);
-	});
+describe('OAuth token worker', () => {
+  it('rejects non-POST requests', async () => {
+    const request = new Request('http://example.com', { method: 'GET' });
+    const ctx = createExecutionContext();
+    const response = await worker.fetch(request, env, ctx);
+    await waitOnExecutionContext(ctx);
+    expect(response.status).toBe(405);
+    expect(await response.text()).toBe('Method Not Allowed');
+  });
 
-	it('responds with Hello World! (integration style)', async () => {
-		const response = await SELF.fetch('http://example.com');
-		expect(await response.text()).toMatchInlineSnapshot(`"Hello World!"`);
-	});
+  it('requires code in request body', async () => {
+    const request = new Request('http://example.com', {
+      method: 'POST',
+      body: JSON.stringify({}),
+    });
+    const ctx = createExecutionContext();
+    const response = await worker.fetch(request, env, ctx);
+    await waitOnExecutionContext(ctx);
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: 'Missing `code`' });
+  });
+
+  it('handles invalid JSON', async () => {
+    const request = new Request('http://example.com', {
+      method: 'POST',
+      body: 'not json',
+    });
+    const ctx = createExecutionContext();
+    const response = await worker.fetch(request, env, ctx);
+    await waitOnExecutionContext(ctx);
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: 'Invalid request' });
+  });
+
+  it('returns access token when code provided', async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(
+        new Response(JSON.stringify({ access_token: 'token123' }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+    Object.assign(env, {
+      GITHUB_CLIENT_ID: 'id',
+      GITHUB_CLIENT_SECRET: 'secret',
+    });
+    const request = new Request('http://example.com', {
+      method: 'POST',
+      body: JSON.stringify({ code: 'abc' }),
+    });
+    const ctx = createExecutionContext();
+    const response = await worker.fetch(request, env, ctx);
+    await waitOnExecutionContext(ctx);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ access_token: 'token123' });
+    expect(fetchMock).toHaveBeenCalledOnce();
+    fetchMock.mockRestore();
+  });
 });


### PR DESCRIPTION
## Summary
- return 400 for invalid JSON requests in OAuth worker
- add tests covering method validation and token exchange

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_6899d1faeb0c8331bd7d586d7347d38c